### PR TITLE
[BT-109]: Support simulation of all React events.

### DIFF
--- a/src/TestCaseFactory.js
+++ b/src/TestCaseFactory.js
@@ -11,8 +11,15 @@ export class TestCase {
     this.dom = ReactDOM.findDOMNode(this.element);
   }
 
-  click(node = this.dom) {
-    TestUtils.Simulate.click(node);
+  trigger(eventName, node = this.dom) {
+    const action = TestUtils.Simulate[eventName];
+    if (!action || typeof action !== 'function') {
+      throw new Error(
+        `TestCase trigger method called with an eventName which isn\'t supported
+         by TestUtils.Simulate: '${eventName}'`
+      );
+    }
+    action(node);
   }
 
   // Mimic $.find()


### PR DESCRIPTION
This will be a breaking change when released, because now events need to be tested with the `trigger` method instead of calling an event-specific method such as `click`.
