### PR TITLE
[BT-352]: Add 'create' convenience method to TestCaseFactory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,10 @@ it('accepts a ReactElement and returns a TestCase instance', () => {
 it('accepts a ReactClass and returns a TestCase instance', () => {
   const props = {
     property1: 'value1',
+    children: <div>A child</div>,
   };
-  const children = (
-    <div>A child</div>
-  );
-  const testCase = TestCaseFactory.createFromClass(TestElement, props, children);
+  // Alternatively, you can use TestCaseFactory.createFromClass here.
+  const testCase = TestCaseFactory.create(TestElement, props);
   expect(testCase instanceof TestCase).toBe(true);
 });
 
@@ -242,7 +241,8 @@ it('accepts a function and returns a TestCase instance', () => {
   const props = {
     property1: 'value1',
   };
-  const testCase = TestCaseFactory.createFromFunction(StatelessTestElement, props);
+  // Alternatively, you can use TestCaseFactory.createFromFunction here.
+  const testCase = TestCaseFactory.create(StatelessTestElement, props);
   expect(testCase instanceof TestCase).toBe(true);
 });
 

--- a/src/TestCaseFactory.js
+++ b/src/TestCaseFactory.js
@@ -124,7 +124,20 @@ function createFromFunction(fn, props) {
   return createFromClass(reactClass, props);
 }
 
+function create(component, props) {
+  if (component.prototype && component.prototype.render) {
+    return createFromClass(component, props);
+  }
+
+  if (typeof component === 'function') {
+    return createFromFunction(component, props);
+  }
+
+  throw new Error('create expects a stateless function or React Class. If you\'re passing in a React Element, use createFromElement.');
+}
+
 export default {
+  create: create,
   createFromElement: createFromElement,
   createFromClass: createFromClass,
   createFromFunction: createFromFunction,

--- a/src/TestCaseFactory.spec.js
+++ b/src/TestCaseFactory.spec.js
@@ -158,6 +158,29 @@ describe('TestCaseFactory', () => {
         }).toThrowError('createFromFunction expects a stateless function, but got a React Class (i.e. a class with a render method).');
       });
     });
+
+    describe('create method', () => {
+      const props = {
+        property1: 'value1',
+        children: <div className="child">A child</div>,
+      };
+
+      it('accepts a ReactClass and returns a TestCase instance', () => {
+        const testCase = TestCaseFactory.create(TestElement, props);
+        expect(testCase instanceof TestCase).toBe(true);
+      });
+
+      it('accepts a function and returns a TestCase instance', () => {
+        const testCase = TestCaseFactory.create(StatelessTestElement, props);
+        expect(testCase instanceof TestCase).toBe(true);
+      });
+
+      it('throws an error when provided a React Element', () => {
+        expect(() => {
+          TestCaseFactory.create(<TestElement/>, props);
+        }).toThrowError('create expects a stateless function or React Class. If you\'re passing in a React Element, use createFromElement.');
+      });
+    });
   });
 
   describe('TestCase instance', () => {


### PR DESCRIPTION
It accepts references to both React Classes and stateless functional components.
